### PR TITLE
생성될 Spot Instance Worker node에 사용할 AMI ID를 지정할 수 있도록 변경

### DIFF
--- a/IaC/kubernetes_cluster/main.tf
+++ b/IaC/kubernetes_cluster/main.tf
@@ -219,7 +219,7 @@ resource "helm_release" "eks-external-dns-integration" {
   }
 
   set {
-    name = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+    name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
     value = module.external_dns_irsa_role.iam_role_arn
   }
 
@@ -437,6 +437,7 @@ resource "null_resource" "create_jupyter_nodepool" {
     echo "${templatefile("${path.module}/templates/jupyter_nodepool.yaml.tpl", {
     eks_cluster_name = module.eks.cluster_name
     node_role_name   = module.karpenter.node_iam_role_name
+    ami_id           = var.ami_id
 })}" > ${path.module}/jupyter_nodepool.yaml
     kubectl apply -f ${path.module}/jupyter_nodepool.yaml
     EOT

--- a/IaC/kubernetes_cluster/templates/jupyter_nodepool.yaml.tpl
+++ b/IaC/kubernetes_cluster/templates/jupyter_nodepool.yaml.tpl
@@ -32,8 +32,9 @@ kind: EC2NodeClass
 metadata:
   name: jupyter-nodeclass
 spec:
+  amiFamily: AL2023
   amiSelectorTerms:
-    - alias: bottlerocket@v1.20.4
+    - id: ${ami_id}
   role: "${node_role_name}"
   subnetSelectorTerms:
     - tags:

--- a/IaC/kubernetes_cluster/var.tf
+++ b/IaC/kubernetes_cluster/var.tf
@@ -43,3 +43,5 @@ variable "route53_domain" {
   type = string
   default = "callisto.ddps.cloud"
 }
+
+variable "ami_id" {}

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,7 @@ module "kubernetes_cluster" {
   source         = "./IaC/kubernetes_cluster"
   main_suffix    = var.main_suffix
   awscli_profile = var.awscli_profile
+  ami_id         = var.ami_id
   region         = var.region
 }
 

--- a/variables.tf.sample
+++ b/variables.tf.sample
@@ -22,3 +22,9 @@ variable "route53_domain" {
   type = string
   default = ""
 }
+
+# AL2023 EKS Optimized AMI
+variable "ami_id" {
+  type = string
+  default = "ami-04f3fb3944c844ddf"
+}


### PR DESCRIPTION
기존 최초 구현에서는 AWS에서 제공하는 bottlerocket AMI를 통해 jupyter를 구동하기 위한 Spot Instance를 생성하도록 하였으나,
사용자 지정 custom ami도 사용할 수 있도록 코드를 수정합니다.

<img width="979" alt="image" src="https://github.com/user-attachments/assets/b21b9e85-ea61-477f-9f02-bdec7997bf8d">

kvm-pvm이 적용된 ami id를 custom하게 지정하였을 때 정상적으로 작동됨을 확인하였습니다. (web browser 접속 테스트도 완료)