### PR TITLE
React-cookie를 이용한 token 관리

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "antd": "^5.20.6",
     "axios": "^1.7.7",
     "react": "^18.3.1",
+    "react-cookie": "^7.2.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",
     "styled-components": "^6.1.13",

--- a/frontend/src/apis/cognito/index.js
+++ b/frontend/src/apis/cognito/index.js
@@ -41,7 +41,8 @@ export const cognitoSignIn = async (args) => {
       return {
         status: COGNITO_SIGN_IN_STATUS.SUCCESS,
         idToken: AuthenticationResult.IdToken || '',
-        accessToken: AuthenticationResult.AccessToken || ''
+        accessToken: AuthenticationResult.AccessToken || '',
+        refreshToken: AuthenticationResult.RefreshToken || ''
       };
     } else if (ChallengeName && Session) {
       return {
@@ -141,6 +142,7 @@ export const cognitoConfirmSignUp = async (email, code) => {
   }
 };
 
+// Refresh Token Usage (with @aws-sdk/client-cognito-identity-provider)
 export const cognitoRefreshAuth = async (refreshToken) => {
   const params = {
     AuthFlow: 'REFRESH_TOKEN_AUTH',

--- a/frontend/src/pages/forms/Login/index.jsx
+++ b/frontend/src/pages/forms/Login/index.jsx
@@ -10,6 +10,7 @@ import {
   useUserStore
 } from '../../../store/zustand.js';
 import { COGNITO_SIGN_IN_STATUS } from '../../../store/constant.js';
+import { Cookies } from 'react-cookie';
 
 export default function Login() {
   const navigate = useNavigate();
@@ -18,10 +19,14 @@ export default function Login() {
   const challengeStore = useChallengeStore();
   const confirmStore = useConfirmStore();
   const { messageApi } = useMessageApi();
+  const cookies = new Cookies();
 
   const onFinish = async (values) => {
     const result = await cognitoSignIn(values);
     if (result.status === COGNITO_SIGN_IN_STATUS.SUCCESS) {
+      cookies.set('idToken', result.idToken);
+      cookies.set('accessToken', result.accessToken);
+      cookies.set('refreshToken', result.refreshToken);
       userStore.setIdToken(result.idToken);
       userStore.setAccessToken(result.accessToken);
       navigate('/overview');

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1560,10 +1560,23 @@
   dependencies:
     "@babel/types" "^7.20.7"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/estree@1.0.5":
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/@types/estree/-/estree-1.0.5.tgz#a6ce3e556e00fd9895dd872dd172ad0d4bd687f4"
   integrity sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==
+
+"@types/hoist-non-react-statics@^3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.5.tgz#dab7867ef789d87e2b4b0003c9d65c49cc44a494"
+  integrity sha512-SbcrWzkKBw2cdwRTwQAswfpB9g9LJWfjtUeW/jvNwbhC8cpmmNYVePa+ncbUe0rGTQ7G3Ff6mYUN2VMfLVr+Sg==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/prop-types@*":
   version "15.7.12"
@@ -1924,6 +1937,11 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-2.0.0.tgz#4b560f649fc4e918dd0ab75cf4961e8bc882d82a"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^0.7.2:
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.7.2.tgz#556369c472a2ba910f2979891b526b3436237ed7"
+  integrity sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==
 
 copy-to-clipboard@^3.3.3:
   version "3.3.3"
@@ -2534,6 +2552,13 @@ hasown@^2.0.0, hasown@^2.0.1, hasown@^2.0.2:
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
   dependencies:
     function-bind "^1.1.2"
+
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 ignore@^5.2.0:
   version "5.3.2"
@@ -3401,6 +3426,15 @@ rc-virtual-list@^3.14.2, rc-virtual-list@^3.5.1, rc-virtual-list@^3.5.2:
     rc-resize-observer "^1.0.0"
     rc-util "^5.36.0"
 
+react-cookie@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-7.2.1.tgz#4a90603df57634bd7edaca325a3b9b584550680a"
+  integrity sha512-UcE6njAy5UmKzU9RywIvvtbHIQydhh6JP55yVbGwQ8Tp/wSPp2HOYVZdRI55zfbkW6zQv9SEs42mS3a9cIUQ0g==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.3.5"
+    hoist-non-react-statics "^3.3.2"
+    universal-cookie "^7.0.0"
+
 react-dom@^18.3.1:
   version "18.3.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-18.3.1.tgz#c2265d79511b57d479b3dd3fdfa51536494c5cb4"
@@ -3409,7 +3443,7 @@ react-dom@^18.3.1:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
 
-react-is@^16.13.1:
+react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -3832,6 +3866,14 @@ unbox-primitive@^1.0.2:
     has-bigints "^1.0.2"
     has-symbols "^1.0.3"
     which-boxed-primitive "^1.0.2"
+
+universal-cookie@^7.0.0:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-7.2.1.tgz#dd8ad1c8b514c59c1b797f9dfdd384bdfff44282"
+  integrity sha512-GEKneQ0sz8qbobkYM5s9elAx6l7GQDNVl3Siqmc7bt/YccyyXWDPn+fht3J1qMcaLwPrzkty3i+dNfPGP2/9hA==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.7.2"
 
 update-browserslist-db@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
#18 에서 언급해주신 AWS Cognito에서 로그인 시 발급 받을 수 있는 token을 react-cookie를 이용해 저장했습니다. 현재 로컬에서 브라우저로 테스트 시, 동일 도메인인 `localhost` 에서는 저장된 토큰값을 조회할 수 있음을 확인했습니다.

<img width="549" alt="스크린샷 2024-10-16 오후 10 38 12" src="https://github.com/user-attachments/assets/1e94ce54-4554-4884-81aa-1d32ec1463f1">

추후 lambda@edge 작업 시 혹여나 cookie 사용에 문제가 있을경우, react-cookie를 이용해 추가적인 cookie 세팅이 필요해보입니다.