### PR TITLE
feat. 로그 수집용 fluentbit 배치

### DIFF
--- a/IaC/kubernetes_cluster/configmap.tf
+++ b/IaC/kubernetes_cluster/configmap.tf
@@ -1,0 +1,33 @@
+resource "kubernetes_config_map" "fluentbit_config" {
+  metadata {
+    name      = "fluent-bit-config"
+    namespace = "kube-system"
+  }
+
+  data = {
+    "fluent-bit.conf" = <<-EOT
+      [SERVICE]
+          Flush         5
+          Log_Level     info
+
+      [INPUT]
+          Name          tail
+          Path          /var/log/containers/*.log
+          Tag           containers.*
+
+      [FILTER]
+          Name          grep
+          Match         containers.*
+
+      [OUTPUT]
+          Name          cloudwatch_logs
+          Match         containers.*
+          region        ap-northeast-2
+          log_group_name ${module.eks.cloudwatch_log_group_name}
+          log_stream_name containers
+          auto_create_group true
+    EOT
+  }
+
+  depends_on = [module.eks]
+}

--- a/IaC/kubernetes_cluster/daemonset.tf
+++ b/IaC/kubernetes_cluster/daemonset.tf
@@ -1,0 +1,69 @@
+resource "kubernetes_daemonset" "fluent_bit" {
+  metadata {
+    name      = "fluent-bit"
+    namespace = "kube-system"
+    labels = {
+      "k8s-app" = "fluent-bit"
+    }
+  }
+
+  spec {
+    selector {
+      match_labels = {
+        "k8s-app" = "fluent-bit"
+      }
+    }
+
+    template {
+      metadata {
+        labels = {
+          "k8s-app" = "fluent-bit"
+        }
+      }
+
+      spec {
+        service_account_name = kubernetes_service_account.fluentbit_sa.metadata[0].name
+
+        container {
+          name  = "fluent-bit"
+          image = "fluent/fluent-bit:latest"
+
+          resources {
+            limits = {
+              memory = "200Mi"
+            }
+            requests = {
+              cpu    = "100m"
+              memory = "100Mi"
+            }
+          }
+
+          volume_mount {
+            name       = "varlog"
+            mount_path = "/var/log/containers"
+            read_only  = true
+          }
+
+          volume_mount {
+            name       = "config"
+            mount_path = "/fluent-bit/etc/"
+          }
+        }
+
+        volume {
+          name = "varlog"
+          host_path {
+            path = "/var/log/containers"
+          }
+        }
+
+        volume {
+          name = "config"
+          config_map {
+            name = kubernetes_config_map.fluentbit_config.metadata[0].name
+          }
+        }
+      }
+    }
+  }
+}

--- a/IaC/kubernetes_cluster/iam.tf
+++ b/IaC/kubernetes_cluster/iam.tf
@@ -1,0 +1,41 @@
+resource "aws_iam_role" "fluentbit_role" {
+  name = "${var.region}-callisto-fluentbit-role-${var.environment}-${var.random_string}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Action = "sts:AssumeRole"
+      Effect = "Allow"
+      Sid    = ""
+      Principal = {
+        Service = "eks.amazonaws.com"
+      }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "fluentbit_policy" {
+  name = "fluentbit-cloudwatch-policy"
+
+  policy = jsonencode({
+    Version   = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "logs:DescribeLogStreams"
+        ]
+        Resource = "arn:aws:logs:*:*:*"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_fluentbit_policy" {
+  role       = aws_iam_role.fluentbit_role.name
+  policy_arn = aws_iam_policy.fluentbit_policy.arn
+}

--- a/IaC/kubernetes_cluster/service_account.tf
+++ b/IaC/kubernetes_cluster/service_account.tf
@@ -1,0 +1,11 @@
+resource "kubernetes_service_account" "fluentbit_sa" {
+  metadata {
+    name      = "fluentbit-sa"
+    namespace = "kube-system"
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.fluentbit_role.arn
+    }
+  }
+
+  depends_on = [module.eks]
+}


### PR DESCRIPTION
- FluentBit가 CloudWatch에 로그를 쓰기 위한 권한인 iam Role 및 Policy 생성
- FluentBit Pod가 AWS IAM Role을 사용할 수 있도록 ServiceAccount 생성
- FluentBit의 Input, Filter, Output 설정을 담은 ConfigMap 생성
- 모든 Node에 FluentBit Pod를 배치하는 DaemonSet 생성