### PR TITLE
Upgrade nginx-ingress-controller version to 4.12.1

### DIFF
--- a/IaC/kubernetes_cluster/ingress_controller.tf
+++ b/IaC/kubernetes_cluster/ingress_controller.tf
@@ -92,7 +92,7 @@ resource "helm_release" "nginx-ingress-controller" {
   name             = "ingress-nginx"
   repository       = "https://kubernetes.github.io/ingress-nginx"
   chart            = "ingress-nginx"
-  version          = "4.11.2"
+  version          = "4.12.1"
   wait             = true
 
   set {


### PR DESCRIPTION
Nginx Ingress Controller에서 매우 치명적인 취약점 https://kubernetes.io/blog/2025/03/24/ingress-nginx-cve-2025-1974/ 이 발견되어 버전을 Upgrade합니다.

현재 Production 환경의 Callisto에서도 Upgrade 진행 완료되었으며, 정상작동합니다.

<img width="983" alt="image" src="https://github.com/user-attachments/assets/2eef1a5a-5cc8-43b6-939d-b8ea3f7cfbd5" />
