### PR TITLE
Fix token uuid mismatch issue

### DIFF
--- a/IaC/frontend/jupyter_auth/index.mjs
+++ b/IaC/frontend/jupyter_auth/index.mjs
@@ -124,7 +124,7 @@ export const handler = async (event) => {
 function extractUuidFromPath(path) {
     // Example: /api/jupyter-access/uuid-part-12345/more/path
     // Adjust regex if UUID format or path structure is different
-    const match = path.match(/\/api\/jupyter-access\/([a-f0-9-]{36})(?:$|[\/\?])/);
+    const match = path.match(/\/api\/jupyter-access\/([a-f0-9-]{36})/);
     return match ? match[1] : null;
 }
 


### PR DESCRIPTION
token uuid mismatch 문제를 해결합니다.

원인은 refresh token 문제로 로직 변경을 거치면서 정규표현식 파싱 regex가 변경되었습니다.

viewer request만 존재할 때는 접속하는 경로가 /api/jupyter-access/<uuid>-<time> 로 끝나도 처리가 되었지만, 기존 regex에서는 /api-jupyter-access/<uuid>-<time>/lab? (lab? 은 jupyter lab 접속 이후 나타나는 상대경로) 처럼 뒷부분에 추가 내용이 붙을경우 처리가 되지 않아 확실히 uuid만 뽑아내도록 수정하였습니다.